### PR TITLE
PR #2972 /2 - feat(auth_admin_passkey_extended): TOTP bypass for admin passkey

### DIFF
--- a/auth_admin_passkey_extended/__init__.py
+++ b/auth_admin_passkey_extended/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/auth_admin_passkey_extended/__manifest__.py
+++ b/auth_admin_passkey_extended/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Ecodica d.o.o.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Auth Admin Passkey - TOTP Bypass",
+    "version": "16.0.1.0.0",
+    "category": "Tools",
+    "summary": "Skip TOTP/2FA verification when admin passkey is used",
+    "author": "Ecodica d.o.o.",
+    "website": "https://ecodica.eu",
+    "license": "AGPL-3",
+    "depends": ["auth_admin_passkey"],
+    "installable": True,
+}

--- a/auth_admin_passkey_extended/models/__init__.py
+++ b/auth_admin_passkey_extended/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_users

--- a/auth_admin_passkey_extended/models/res_users.py
+++ b/auth_admin_passkey_extended/models/res_users.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Ecodica d.o.o.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+from odoo.http import request
+from odoo.tools import config
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _mfa_url(self):
+        """Skip TOTP/2FA when admin passkey is used and config allows it."""
+        if request and request.session.get("ignore_totp"):
+            return None
+        return super()._mfa_url()
+
+    @api.model
+    def _send_email_passkey(self, login_user):
+        """Set ignore_totp session flag when admin passkey authenticates.
+
+        This method is called by auth_admin_passkey's _check_credentials
+        only when the passkey matches, making it the ideal hook point to
+        set the session flag before _mfa_url is evaluated.
+        """
+        if request:
+            request.session["ignore_totp"] = config.get(
+                "auth_admin_passkey_ignore_totp", False
+            )
+        return super()._send_email_passkey(login_user)


### PR DESCRIPTION
## Summary
- New module `auth_admin_passkey_extended` that skips TOTP/2FA when admin passkey is used
- Extends OCA `auth_admin_passkey` — hooks `_send_email_passkey()` to set session flag, overrides `_mfa_url()` to skip TOTP when flag present
- Controlled by `auth_admin_passkey_ignore_totp = True` in odoo.conf (disabled by default)

## Test plan
- [ ] Install on DB with auth_admin_passkey + auth_totp
- [ ] Enable TOTP on test user, login with passkey → TOTP skipped
- [ ] Login with real password → TOTP still required
- [ ] Remove config param → passkey login requires TOTP again